### PR TITLE
added callbacks for log events

### DIFF
--- a/src/JoeScan.LogScanner.Core/Extensions/TaskExtensions.cs
+++ b/src/JoeScan.LogScanner.Core/Extensions/TaskExtensions.cs
@@ -1,0 +1,35 @@
+﻿namespace JoeScan.LogScanner.Core.Extensions;
+//TODO: add https://www.meziantou.net/fire-and-forget-a-task-in-dotnet.htm to credits
+public static class TaskExtensions
+{
+    /// <summary>
+    /// Observes the task to avoid the UnobservedTaskException event to be raised.
+    /// </summary>
+    public static void Forget(this Task task)
+    {
+        // note: this code is inspired by a tweet from Ben Adams: https://twitter.com/ben_a_adams/status/1045060828700037125
+        // Only care about tasks that may fault (not completed) or are faulted,
+        // so fast-path for SuccessfullyCompleted and Canceled tasks.
+        if (!task.IsCompleted || task.IsFaulted)
+        {
+            // use "_" (Discard operation) to remove the warning IDE0058: Because this call is not awaited, execution of the current method continues before the call is completed
+            // https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/functional/discards?WT.mc_id=DT-MVP-5003978#a-standalone-discard
+            _ = ForgetAwaited(task);
+        }
+
+        // Allocate the async/await state machine only when needed for performance reasons.
+        // More info about the state machine: https://blogs.msdn.microsoft.com/seteplia/2017/11/30/dissecting-the-async-methods-in-c/?WT.mc_id=DT-MVP-5003978
+        static async Task ForgetAwaited(Task task)
+        {
+            try
+            {
+                // No need to resume on the original SynchronizationContext, so use ConfigureAwait(false)
+                await task.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Nothing to do here
+            }
+        }
+    }
+}

--- a/src/JoeScan.LogScanner.Core/Interfaces/ILogStatusEventConsumer.cs
+++ b/src/JoeScan.LogScanner.Core/Interfaces/ILogStatusEventConsumer.cs
@@ -1,0 +1,12 @@
+﻿namespace JoeScan.LogScanner.Core.Interfaces;
+
+public interface ILogStatusEventConsumer
+{
+    void LogCollectionIdleStarted();
+    void LogCollectionIdleEnded();
+
+    void LogCollectionStarted();
+    void LogCollectionAborted();
+    void LogCollectionEnded();
+    
+}

--- a/src/JoeScan.LogScanner.Headless/Program.cs
+++ b/src/JoeScan.LogScanner.Headless/Program.cs
@@ -26,7 +26,8 @@ var container = builder.Build();
 
 using var scope = container.BeginLifetimeScope();
 var engine= scope.Resolve<LogScannerEngine>();
-engine.SetActiveAdapter(engine.AvailableAdapters.First(q=>q.Id.Equals(Guid.Parse("{6EAE7379-E27D-4BFE-B304-CF16D40E9A9B}")))); 
+//engine.SetActiveAdapter(engine.AvailableAdapters.First(q=>q.Id.Equals(Guid.Parse("{6EAE7379-E27D-4BFE-B304-CF16D40E9A9B}")))); // JS-25
+engine.SetActiveAdapter(engine.AvailableAdapters.First(q=>q.Id.Equals(Guid.Parse("{C79255EF-9AB8-4B6D-B3F1-FA4D37AFD021}")))); // Synthetic
 engine.Start();
 
 autoResetEvent.WaitOne();

--- a/src/LogScanner.VendorSample/SampleLogStatusEventConsumer.cs
+++ b/src/LogScanner.VendorSample/SampleLogStatusEventConsumer.cs
@@ -1,0 +1,33 @@
+﻿using JoeScan.LogScanner.Core.Interfaces;
+
+namespace LogScanner.VendorSample;
+
+public class SampleLogStatusEventConsumer : ILogStatusEventConsumer, IDisposable
+{
+    public void LogCollectionIdleStarted()
+    {
+        
+    }
+
+    public void LogCollectionIdleEnded()
+    {
+    }
+
+    public void LogCollectionStarted()
+    {
+    }
+
+    public void LogCollectionAborted()
+    {
+    }
+
+    public void LogCollectionEnded()
+    {
+     
+    }
+
+    public void Dispose()
+    {
+
+    }
+}

--- a/src/LogScanner.VendorSample/VendorModule.cs
+++ b/src/LogScanner.VendorSample/VendorModule.cs
@@ -8,5 +8,6 @@ public class VendorModule : Module
     protected override void Load(ContainerBuilder builder)
     {
         builder.RegisterType<SampleConsumer>().As<ILogModelConsumerPlugin>().As<IDisposable>();
+        builder.RegisterType<SampleLogStatusEventConsumer>().As<ILogStatusEventConsumer>().As<IDisposable>();
     }
 }


### PR DESCRIPTION
this is a very simple implementation of a callback interface that executes the methods provided by the ILogStatusEventConsumer implementation (if there are any registered) on a task, without checking results. This is done to prevent a misbehaving plugin to tank the performance of the LogAssembler